### PR TITLE
[bugfix][Android9.0 无网络]：解决虚拟环境无网络的缺陷

### DIFF
--- a/lib/src/main/java/com/lody/virtual/client/ipc/VPackageManager.java
+++ b/lib/src/main/java/com/lody/virtual/client/ipc/VPackageManager.java
@@ -10,7 +10,6 @@ import android.content.pm.PermissionInfo;
 import android.content.pm.ProviderInfo;
 import android.content.pm.ResolveInfo;
 import android.content.pm.ServiceInfo;
-import android.os.Build;
 import android.os.RemoteException;
 
 import com.lody.virtual.client.env.VirtualRuntime;
@@ -173,7 +172,7 @@ public class VPackageManager {
             }
             final int P = 28;
             final String APACHE_LEGACY = "/system/framework/org.apache.http.legacy.boot.jar";
-            if (android.os.Build.VERSION.SDK_INT >= P && info.targetSdkVersion < P) {
+            if (android.os.Build.VERSION.SDK_INT >= P && info.targetSdkVersion <= P) {
                 String[] newSharedLibraryFiles;
                 if (info.sharedLibraryFiles == null) {
                     newSharedLibraryFiles = new String[]{APACHE_LEGACY};


### PR DESCRIPTION
当真机环境为 Android9.0，且虚拟环境中 app的info.targetSdkVersion=28时，虚拟环境无网络访问的缺陷，应该把info.targetSdkVersion <28 应改为info.targetSdkVersion<=28